### PR TITLE
[1.x] Adds `pest` mutate support

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -19,6 +19,10 @@ if (filter_var($_SERVER['PAO_DISABLE'] ?? false, FILTER_VALIDATE_BOOLEAN)) {
     return;
 }
 
+if (getenv('PEST_MUTATION_TESTING') !== false) {
+    return;
+}
+
 $agent = AgentDetector::detect();
 
 if (! $agent->isAgent && ! filter_var($_SERVER['PAO_FORCE'] ?? false, FILTER_VALIDATE_BOOLEAN)) {

--- a/src/Drivers/PestMutate/Starter.php
+++ b/src/Drivers/PestMutate/Starter.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Pao\Drivers\PestMutate;
+
+use Laravel\Pao\Drivers\Concerns\ProfileCollector;
+use Laravel\Pao\Drivers\Starter as BaseStarter;
+use Pest\Mutate\Contracts\Mutator;
+use Pest\Mutate\MutationSuite;
+use Pest\Mutate\Repositories\MutationRepository;
+use Pest\Mutate\Support\MutationTestResult;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Throwable;
+
+/**
+ * @internal
+ *
+ * @codeCoverageIgnore
+ *
+ * @phpstan-type UntestedDetail array{file: string, line: int, mutator: string, diff?: array{original: string, mutated: string}}
+ */
+final class Starter extends BaseStarter
+{
+    public function name(): string
+    {
+        return 'pest-mutate';
+    }
+
+    public function start(): void
+    {
+        ProfileCollector::startTimerFromNanoseconds(hrtime(true));
+
+        $this->discardStdout();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function parse(): ?array
+    {
+        if (! class_exists(MutationSuite::class, false)) {
+            return null;
+        }
+
+        try {
+            $repository = MutationSuite::instance()->repository;
+
+            return $this->omitEmpty([
+                'score' => round($repository->score(), 2),
+                'mutations' => $repository->total(),
+                'tested' => $repository->tested(),
+                'untested' => $repository->untested(),
+                'uncovered' => $repository->uncovered(),
+                'timeout' => $repository->timedOut(),
+                'pending' => $repository->notRun(),
+                'duration_ms' => ProfileCollector::durationMs(),
+                'untested_details' => $this->untestedDetails($repository),
+            ]);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function omitEmpty(array $result): array
+    {
+        foreach (['tested', 'untested', 'uncovered', 'timeout', 'pending'] as $key) {
+            if ($result[$key] === 0) {
+                unset($result[$key]);
+            }
+        }
+
+        if ($result['untested_details'] === []) {
+            unset($result['untested_details']);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return list<UntestedDetail>
+     */
+    private function untestedDetails(MutationRepository $repository): array
+    {
+        $cwd = getcwd();
+        $prefix = $cwd === false ? '' : $cwd.DIRECTORY_SEPARATOR;
+
+        $details = [];
+
+        foreach ($repository->all() as $collection) {
+            foreach ($collection->tests() as $test) {
+                if ($test->result() !== MutationTestResult::Untested) {
+                    continue;
+                }
+
+                $mutation = $test->mutation;
+
+                $file = $mutation->file->getRealPath();
+                $file = $file === false ? $mutation->file->getPathname() : $file;
+
+                if ($prefix !== '' && str_starts_with($file, $prefix)) {
+                    $file = substr($file, strlen($prefix));
+                }
+
+                /** @var class-string<Mutator> $mutator */
+                $mutator = $mutation->mutator;
+
+                $detail = [
+                    'file' => $file,
+                    'line' => $mutation->startLine,
+                    'mutator' => $mutator::name(),
+                ];
+
+                $diff = $this->formatDiff($mutation->diff);
+
+                if ($diff !== null) {
+                    $detail['diff'] = $diff;
+                }
+
+                $details[] = $detail;
+            }
+        }
+
+        return $details;
+    }
+
+    /**
+     * @return array{original: string, mutated: string}|null
+     */
+    private function formatDiff(string $diff): ?array
+    {
+        if ($diff === '') {
+            return null;
+        }
+
+        $plain = (new OutputFormatter)->format($diff) ?? '';
+
+        $original = [];
+        $mutated = [];
+
+        foreach (explode("\n", $plain) as $line) {
+            $line = trim($line);
+
+            if (str_starts_with($line, '-') && ! str_starts_with($line, '---')) {
+                $original[] = trim(substr($line, 1));
+            } elseif (str_starts_with($line, '+') && ! str_starts_with($line, '+++')) {
+                $mutated[] = trim(substr($line, 1));
+            }
+        }
+
+        if ($original === [] && $mutated === []) {
+            return null;
+        }
+
+        return [
+            'original' => implode("\n", $original),
+            'mutated' => implode("\n", $mutated),
+        ];
+    }
+}

--- a/src/Drivers/Starter.php
+++ b/src/Drivers/Starter.php
@@ -36,6 +36,15 @@ abstract class Starter implements Driver
         $execution->filter = stream_filter_append(STDOUT, 'agent_output_capture', STREAM_FILTER_WRITE) ?: null;
     }
 
+    protected function discardStdout(): void
+    {
+        $this->registerNullFilter();
+
+        $execution = Execution::current();
+
+        $execution->filter = stream_filter_append(STDOUT, 'agent_output_null', STREAM_FILTER_WRITE) ?: null;
+    }
+
     protected function silenceStderr(): void
     {
         stream_filter_append(STDERR, 'agent_output_null', STREAM_FILTER_WRITE);

--- a/src/Execution.php
+++ b/src/Execution.php
@@ -48,7 +48,7 @@ final class Execution
 
         $starter = match ($binary) {
             'paratest' => new Drivers\Paratest\Starter,
-            'pest' => new Drivers\Pest\Starter,
+            'pest' => self::resolvePestStarter($argv),
             'phpstan', 'phpstan.phar' => new Drivers\Phpstan\Starter,
             'phpunit' => new Drivers\Phpunit\Starter,
             'rector' => new Drivers\Rector\Starter,
@@ -63,6 +63,16 @@ final class Execution
 
             $starter->start();
         }
+    }
+
+    /**
+     * @param  array<int, string>  $argv
+     */
+    private static function resolvePestStarter(array $argv): Driver
+    {
+        return in_array('--mutate', $argv, true)
+            ? new Drivers\PestMutate\Starter
+            : new Drivers\Pest\Starter;
     }
 
     public static function running(): bool

--- a/tests/Drivers/PestMutateTest.php
+++ b/tests/Drivers/PestMutateTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+const MUTATE_FIXTURE = 'tests/Fixtures/Mutate';
+const MUTATE_EMPTY_FIXTURE = 'tests/Fixtures/Mutate/empty';
+
+it('outputs structured json for a mutation run', function (): void {
+    $output = decodeOutput(runMutate(MUTATE_FIXTURE));
+
+    expect($output['tool'])->toBe('pest-mutate')
+        ->and($output['mutations'])->toBeGreaterThan(0)
+        ->and($output['untested'])->toBeGreaterThan(0)
+        ->and($output['tested'])->toBeGreaterThan(0)
+        ->and($output['score'])->toBeGreaterThan(0)
+        ->and($output['duration_ms'])->toBeInt()
+        ->and($output['duration_ms'])->toBeGreaterThanOrEqual(0)
+        ->and((float) $output['score'])->toBe(round($output['tested'] / $output['mutations'] * 100, 2));
+
+    expect($output)->not->toHaveKey('uncovered')
+        ->and($output)->not->toHaveKey('timeout')
+        ->and($output)->not->toHaveKey('pending');
+});
+
+it('includes untested mutation diff details as structured plain text', function (): void {
+    $output = decodeOutput(runMutate(MUTATE_FIXTURE));
+
+    expect($output['untested_details'])->toHaveCount($output['untested']);
+
+    foreach ($output['untested_details'] as $detail) {
+        expect($detail['file'])->toEndWith('Calculator.php')
+            ->and($detail['line'])->toBeInt()
+            ->and($detail['mutator'])->toBeString();
+    }
+
+    $diffs = array_column($output['untested_details'], 'diff');
+    $comparison = array_values(array_filter($diffs, fn (array $diff): bool => str_contains((string) $diff['original'], 'return $number')));
+
+    expect($comparison)->not->toBeEmpty();
+
+    foreach ($comparison as $diff) {
+        expect($diff)->toHaveKeys(['original', 'mutated'])
+            ->and($diff['original'])->toBe('return $number > 0;')
+            ->and($diff['mutated'])->toContain('return $number')
+            ->and($diff['original'].$diff['mutated'])->not->toContain('\\>')
+            ->and($diff['original'].$diff['mutated'])->not->toContain('<fg');
+    }
+});
+
+it('reports no mutations created when nothing is mutable', function (): void {
+    $output = decodeOutput(runMutate(MUTATE_EMPTY_FIXTURE));
+
+    expect($output['tool'])->toBe('pest-mutate')
+        ->and($output['mutations'])->toBe(0)
+        ->and($output['score'])->toBe(0)
+        ->and($output)->not->toHaveKey('untested_details');
+});
+
+it('emits a single pest-mutate document without normal pest output', function (): void {
+    $raw = cleanOutput(runMutate(MUTATE_FIXTURE)->getOutput());
+
+    expect(substr_count($raw, '"tool":"pest-mutate"'))->toBe(1)
+        ->and($raw)->not->toContain('"tool":"pest"');
+});
+
+it('does not affect output when no agent is detected', function (): void {
+    $raw = cleanOutput(runMutate(MUTATE_FIXTURE, withAgent: false)->getOutput());
+
+    expect($raw)->not->toContain('"tool":"pest-mutate"');
+});
+
+it('rotutes a parallel mutation run to the pest-mutate driver', function (): void {
+    $output = decodeOutput(runMutate(MUTATE_FIXTURE, extraArgs: ['--parallel']));
+
+    expect($output['tool'])->toBe('pest-mutate')
+        ->and($output)->toHaveKey('mutations');
+});

--- a/tests/Fixtures/Mutate/CalculatorTest.php
+++ b/tests/Fixtures/Mutate/CalculatorTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/src/Calculator.php';
+
+covers(MutateCalculator::class);
+
+it('detects a positive number', function (): void {
+    expect((new MutateCalculator)->isPositive(5))->toBeTrue();
+});
+
+it('adds two numbers', function (): void {
+    expect((new MutateCalculator)->add(2, 3))->toBe(5);
+});

--- a/tests/Fixtures/Mutate/empty/NoopTest.php
+++ b/tests/Fixtures/Mutate/empty/NoopTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/src/Noop.php';
+
+covers(MutateNoop::class);
+
+it('runs without mutable statements', function (): void {
+    (new MutateNoop)->run();
+
+    expect(true)->toBeTrue();
+});

--- a/tests/Fixtures/Mutate/empty/phpunit.xml
+++ b/tests/Fixtures/Mutate/empty/phpunit.xml
@@ -3,11 +3,14 @@
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
     colors="false"
     cacheDirectory=".phpunit.cache">
-<testsuites>
+    <testsuites>
         <testsuite name="default">
             <directory suffix="Test.php">.</directory>
-            <exclude>./Pest</exclude>
-            <exclude>./Mutate</exclude>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/Fixtures/Mutate/empty/src/Noop.php
+++ b/tests/Fixtures/Mutate/empty/src/Noop.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+final class MutateNoop
+{
+    public function run(): void
+    {
+        //
+    }
+}

--- a/tests/Fixtures/Mutate/phpunit.xml
+++ b/tests/Fixtures/Mutate/phpunit.xml
@@ -3,11 +3,15 @@
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
     colors="false"
     cacheDirectory=".phpunit.cache">
-<testsuites>
+    <testsuites>
         <testsuite name="default">
             <directory suffix="Test.php">.</directory>
-            <exclude>./Pest</exclude>
-            <exclude>./Mutate</exclude>
+            <exclude>./empty</exclude>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/Fixtures/Mutate/src/Calculator.php
+++ b/tests/Fixtures/Mutate/src/Calculator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+final class MutateCalculator
+{
+    public function isPositive(int $number): bool
+    {
+        return $number > 0;
+    }
+
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -33,6 +33,41 @@ function runWith(string $binary, string $filter, bool $withAgent = true, array $
     return $process;
 }
 
+/**
+ * @param  array<int, string>  $extraArgs
+ */
+function runMutate(string $dir, bool $withAgent = true, array $extraArgs = []): Process
+{
+    $source = $dir.'/src';
+
+    $command = [
+        PHP_BINARY,
+        '-d', 'pcov.enabled=1',
+        '-d', 'pcov.directory='.$source,
+        'vendor/bin/pest',
+        '--mutate',
+        '--path='.$source,
+        '--configuration', $dir.'/phpunit.xml',
+        ...$extraArgs,
+    ];
+
+    $env = array_merge(buildAgentEnvironment($withAgent), [
+        'PARATEST' => false,
+        'TEST_TOKEN' => false,
+        'UNIQUE_TEST_TOKEN' => false,
+    ]);
+
+    $process = new Process(
+        command: $command,
+        cwd: dirname(__DIR__),
+        env: $env,
+    );
+
+    $process->run();
+
+    return $process;
+}
+
 function cleanOutput(string $raw): string
 {
     $raw = str_replace("\r", '', $raw);


### PR DESCRIPTION
I had originally planned to create a pull request to add support for the PHP package [infection](https://github.com/infection/infection), but I realized that pest already has a built in mutation testing option. So, I’m proposing to implement support for pest’s standard `--mutate` option first, and if that’s well received, I’d like to submit a pull request for infection support in the future.

## Summary

PAO converts test, analysis tool output into compact JSON for AI agents, but mutation testing　(`pest --mutate`) is not handled. 
It currently falls through to the normal pest driver, which reports the initial test suite as `{"tool":"pest","result":"passed",...}` and dumps the whole mutation output into raw as unstructured text burying the real mutation result.

This PR adds a dedicated pest mutate driver that emits a compact, structured result.

## What it does

- Routes `pest --mutate` to a new `Drivers\PestMutate\Starter` (binary stays pest routing branches on --mutate).
- Reads results from `Pest\Mutate\MutationSuite::instance()->repository` at shutdown and emits:
```
{"tool":"pest-mutate", score, mutations, tested, untested, uncovered, timeout, pending, duration_ms, untested_details}
```
- untested_details: file, line, mutator, and a structured diff(original, mutated) (color tags, escapes, markers and indentation stripped).
- Suppresses PAO in mutation child processes via the `PEST_MUTATION_TESTING` env marker (prevents duplicate output).
- `--parallel` / `--processes` mutation runs are handled by the same `pest-mutate` driver. The parent `MutationSuite` repository is aggregated in parallel too, so the same shutdown read works.
- Omits zero-count categories and empty untested_details. Always keeps score, mutations, duration_ms.

## Tests

- Why the parallel case only asserts routing: nested parallel (the suite already runs under `pest --parallel`) can't collect coverage, so the parallel test only checks that the run goes to the right driver. Wether the numbers (score and counts) come out correctly is verified by the non parallel tests.

## Before / After

Verified in a Laravel 13 + Pest 4.7.3 app, with PAO installed, running:

```bash
pest --mutate --path=app/Support/PriceCalculator.php
```

(`PriceCalculator` is covered by a loose test, so some mutations survive.)

### Before: current PAO (mutation falls through to the pest driver)

```json
{
  "tool": "pest",
  "result": "passed",
  "tests": 2,
  "passed": 2,
  "duration_ms": 1385,
  "raw": [
    "Mutating application files..",
    "11 Mutations for 1 Files created",
    "UNTESTED app/Support/PriceCalculator.php > Line 19: GreaterOrEqualToGreater - ID: bb05715b...",
    "- return $total >= 5000;",
    "+ return $total > 5000;",
    "... (one block per untested mutation) ...",
    "Mutations: 4 untested, 7 tested",
    "Score: 63.64%"
  ]
}
```

### After: this PR

```json
{
  "tool": "pest-mutate",
  "score": 63.64,
  "mutations": 11,
  "tested": 7,
  "untested": 4,
  "duration_ms": 1515,
  "untested_details": [
    {
      "file": "app/Support/PriceCalculator.php",
      "line": 19,
      "mutator": "GreaterOrEqualToGreater",
      "diff": { "original": "return $total >= 5000;", "mutated": "return $total > 5000;" }
    }
  ]
}
```