### PR TITLE
[1.x] Adds stack traces to test failures and errors

### DIFF
--- a/src/Drivers/Concerns/TestResultParsable.php
+++ b/src/Drivers/Concerns/TestResultParsable.php
@@ -30,6 +30,8 @@ use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
  */
 trait TestResultParsable
 {
+    private const int STACK_TRACE_LIMIT = 5;
+
     public ?TestResult $testResult = null;
 
     private bool $executionFinished = false;
@@ -166,7 +168,7 @@ trait TestResultParsable
 
         $durationMs = ProfileCollector::durationMs();
 
-        /** @var list<array{test: string, file: string, line: int, message: string}> $failureDetails */
+        /** @var list<array{test: string, file: string, line: int, message: string, trace?: list<string>}> $failureDetails */
         $failureDetails = [];
 
         foreach ($testResult->testFailedEvents() as $event) {
@@ -180,27 +182,29 @@ trait TestResultParsable
 
                 [$file, $line] = $this->resolveTestLocation($file, $line, $throwable);
 
-                $failureDetails[] = [
-                    'test' => $test instanceof TestMethod ? $test->nameWithClass() : $test->id(),
-                    'file' => $file,
-                    'line' => $line,
-                    'message' => $message,
-                ];
+                $failureDetails[] = $this->buildTestDetail(
+                    $test instanceof TestMethod ? $test->nameWithClass() : $test->id(),
+                    $file,
+                    $line,
+                    $message,
+                    $throwable,
+                );
 
                 continue;
             }
 
             [$file, $line] = $this->resolveTestLocation('', 0, $throwable);
 
-            $failureDetails[] = [
-                'test' => $event->testClassName().'::'.$event->calledMethod()->methodName(),
-                'file' => $file,
-                'line' => $line,
-                'message' => $message,
-            ];
+            $failureDetails[] = $this->buildTestDetail(
+                $event->testClassName().'::'.$event->calledMethod()->methodName(),
+                $file,
+                $line,
+                $message,
+                $throwable,
+            );
         }
 
-        /** @var list<array{test: string, file: string, line: int, message: string}> $errorDetails */
+        /** @var list<array{test: string, file: string, line: int, message: string, trace?: list<string>}> $errorDetails */
         $errorDetails = [];
 
         foreach ($testResult->testErroredEvents() as $event) {
@@ -213,12 +217,13 @@ trait TestResultParsable
 
                 [$file, $line] = $this->resolveTestLocation($file, $line, $throwable);
 
-                $errorDetails[] = [
-                    'test' => $test instanceof TestMethod ? $test->nameWithClass() : $test->id(),
-                    'file' => $file,
-                    'line' => $line,
-                    'message' => $message,
-                ];
+                $errorDetails[] = $this->buildTestDetail(
+                    $test instanceof TestMethod ? $test->nameWithClass() : $test->id(),
+                    $file,
+                    $line,
+                    $message,
+                    $throwable,
+                );
             }
         }
 
@@ -297,6 +302,40 @@ trait TestResultParsable
         }
 
         return $result;
+    }
+
+    /**
+     * @return array{test: string, file: string, line: int, message: string, trace?: list<string>}
+     */
+    private function buildTestDetail(string $test, string $file, int $line, string $message, Throwable $throwable): array
+    {
+        $detail = [
+            'test' => $test,
+            'file' => $file,
+            'line' => $line,
+            'message' => $message,
+        ];
+
+        $trace = $this->stackTraceFrames($throwable);
+
+        if ($trace !== []) {
+            $detail['trace'] = $trace;
+        }
+
+        return $detail;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stackTraceFrames(Throwable $throwable): array
+    {
+        $frames = array_values(array_filter(
+            array_map(trim(...), explode("\n", $throwable->stackTrace())),
+            fn (string $frame): bool => $frame !== '',
+        ));
+
+        return array_slice($frames, 0, self::STACK_TRACE_LIMIT);
     }
 
     private function failsOnEmptyTestSuite(): bool

--- a/src/Execution.php
+++ b/src/Execution.php
@@ -14,7 +14,7 @@ use Laravel\Pao\UserFilters\CaptureFilter;
  *
  * @codeCoverageIgnore
  *
- * @phpstan-type TestDetail array{test: string, file: string, line: int, message: string}
+ * @phpstan-type TestDetail array{test: string, file: string, line: int, message: string, trace?: list<string>}
  * @phpstan-type ProfileEntry array{test: string, file: string, duration_ms: int}
  * @phpstan-type Result array{result: 'passed'|'failed', tests: int, passed: int, duration_ms: int, failed?: int, failures?: list<TestDetail>, errors?: int, error_details?: list<TestDetail>, skipped?: int, profile?: list<ProfileEntry>, raw?: list<string>}
  */

--- a/tests/Drivers/ParatestTest.php
+++ b/tests/Drivers/ParatestTest.php
@@ -143,6 +143,12 @@ it('merges test outcomes reported by multiple workers', function (): void {
         ->and($output['failures'][0]['file'])->toEndWith('FailingTest.php');
 });
 
+it('includes stack traces for failures', function (): void {
+    $output = decodeOutput(runWith('paratest', 'FailingTest'));
+
+    expect($output['failures'][0]['trace'][0])->toEndWith('FailingTest.php:18');
+});
+
 it('outputs normal paratest output when no agent is detected', function (): void {
     $process = runWith('paratest', 'PassingTest', withAgent: false);
 

--- a/tests/Drivers/PestTest.php
+++ b/tests/Drivers/PestTest.php
@@ -132,6 +132,12 @@ it('outputs normal pest output when no agent is detected', function (): void {
         ->and($process->getOutput())->toContain('passed');
 });
 
+it('includes stack traces for failures', function (): void {
+    $output = decodeOutput(runWith('pest', 'FailingTest'));
+
+    expect($output['failures'][0]['trace'][0])->toEndWith('FailingTest.php:18');
+});
+
 it('outputs json when PAO_FORCE is set without an agent', function (): void {
     $output = decodeOutput(runWith('pest', 'PassingTest', withAgent: false, extraEnv: ['PAO_FORCE' => '1']));
 

--- a/tests/Drivers/PhpunitTest.php
+++ b/tests/Drivers/PhpunitTest.php
@@ -141,6 +141,22 @@ it('outputs json for multiple failures and errors', function (): void {
         ->and($output['error_details'])->toHaveCount(1);
 });
 
+it('includes stack traces for failures and errors', function (): void {
+    $output = decodeOutput(runWith('phpunit', 'MultipleFailuresTest'));
+
+    expect($output['failures'][0]['trace'])->toHaveCount(1)
+        ->and($output['failures'][0]['trace'][0])->toEndWith('MultipleFailuresTest.php:18')
+        ->and($output['error_details'][0]['trace'])->toHaveCount(1)
+        ->and($output['error_details'][0]['trace'][0])->toEndWith('MultipleFailuresTest.php:28');
+});
+
+it('limits stack traces to five frames', function (): void {
+    $output = decodeOutput(runWith('phpunit', 'DeepStackTest'));
+
+    expect($output['failures'][0]['trace'])->toHaveCount(5)
+        ->and($output['failures'][0]['trace'][0])->toEndWith('DeepStackTest.php:19');
+});
+
 it('outputs normal phpunit output when no agent is detected', function (): void {
     $process = runWith('phpunit', 'PassingTest', withAgent: false);
 

--- a/tests/Fixtures/DeepStackTest.php
+++ b/tests/Fixtures/DeepStackTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+final class DeepStackTest extends TestCase
+{
+    public function test_it_fails_deep_in_the_stack(): void
+    {
+        $this->descend(15);
+    }
+
+    private function descend(int $depth): void
+    {
+        if ($depth === 0) {
+            $this->assertTrue(false);
+        } else {
+            $this->descend($depth - 1);
+        }
+    }
+}


### PR DESCRIPTION
Adds a `trace` array to each entry in `failures` and `error_details`, capped at 5 frames.

### Why

When a test fails below the test body — in a shared assertion helper, a factory, a service — nothing in the payload says where. `line` is the test method's declaration line, and the message is just the diff. 

Agents hit that dead end and re-run with `PAO_DISABLE=1`; In my experience, it added that to memory on its own so basically PAO was disabled for every test run after that.

```diff
{
  "test": "Tests\\Unit\\CheckoutTest::test_deep_assertion_failure",
  "file": "tests/Unit/CheckoutTest.php",
  "line": 24,
  "message": "Failed asserting that two strings are identical.\n--- Expected\n+++ Actual\n@@ @@\n-'USD 17.99'\n+'USD 17.49'",
+ "trace": [
+   "tests/Support/TotalsInspector.php:12",
+   "tests/Support/CheckoutAssertions.php:11",
+   "tests/Unit/CheckoutTest.php:26"
+ ]
}
```

`trace[0]` is the assertion that failed — a file the payload doesn't mention today. The rest walks back to the call site in the test body. Errors work the same way: `trace[0]` is the `throw`.

Passing runs are unchanged, and a failure only costs a few filenames. Frames come from PHPUnit's filtered trace, so vendor noise is already stripped.

### Notes

- `line` is left alone — existing behaviour, and correcting it felt like a separate discussion.
- The cap is one constant (`STACK_TRACE_LIMIT = 5`). Happy to change the number.
- Implemented in `TestResultParsable`, so PHPUnit, Pest, Paratest and `pest --parallel` all pick it up.