### PR TITLE
fix: bypass formatter for raw output

### DIFF
--- a/src/Laravel/PaoOutputStyle.php
+++ b/src/Laravel/PaoOutputStyle.php
@@ -32,7 +32,7 @@ final class PaoOutputStyle extends OutputStyle
     #[\Override]
     public function write(string|iterable $messages, bool $newline = false, int $options = 0): void
     {
-        parent::write($this->clean($messages), $newline, $options);
+        parent::write($this->clean($messages, ($options & self::OUTPUT_RAW) === 0), $newline, $options);
     }
 
     /**
@@ -41,17 +41,23 @@ final class PaoOutputStyle extends OutputStyle
     #[\Override]
     public function writeln(string|iterable $messages, int $type = self::OUTPUT_NORMAL): void
     {
-        parent::writeln($this->clean($messages), $type);
+        parent::writeln($this->clean($messages, ($type & self::OUTPUT_RAW) === 0), $type);
     }
 
     /**
      * @param  string|iterable<string>  $messages
      * @return string|list<string>
      */
-    private function clean(string|iterable $messages): string|array
+    private function clean(string|iterable $messages, bool $format): string|array
     {
-        $formatter = self::$formatter ??= new OutputFormatter(false);
-        $strip = fn (string $m): string => OutputCleaner::clean((string) $formatter->format($m));
+        $strip = function (string $message) use ($format): string {
+            if ($format) {
+                $formatter = self::$formatter ??= new OutputFormatter(false);
+                $message = (string) $formatter->format($message);
+            }
+
+            return OutputCleaner::clean($message);
+        };
 
         if (is_string($messages)) {
             return $strip($messages);

--- a/tests/Laravel/PaoOutputStyleTest.php
+++ b/tests/Laravel/PaoOutputStyleTest.php
@@ -97,6 +97,29 @@ it('strips ANSI and style tags together', function (): void {
     expect(trim($output->fetch()))->toBe('Value');
 });
 
+it('preserves style tags in raw write output', function (): void {
+    $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+    $style = new PaoOutputStyle(new ArrayInput([]), $output);
+
+    $style->write("\e[32m<info>Value</info>\e[0m", options: OutputInterface::OUTPUT_RAW);
+
+    expect($output->fetch())->toBe('<info>Value</info>');
+});
+
+it('preserves style tags in raw writeln output', function (): void {
+    $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+    $style = new PaoOutputStyle(new ArrayInput([]), $output);
+
+    $style->writeln([
+        '<info>first</info>',
+        '<comment>second</comment>',
+    ], OutputInterface::OUTPUT_RAW);
+
+    expect($output->fetch())->toBe(
+        '<info>first</info>'.PHP_EOL.'<comment>second</comment>'.PHP_EOL,
+    );
+});
+
 it('collapses style-wrapped dot separators to ..', function (): void {
     $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
     $style = new PaoOutputStyle(new ArrayInput([]), $output);


### PR DESCRIPTION
## Summary

`PaoOutputStyle` runs all messages through `OutputFormatter`, including `OUTPUT_RAW` 
can make large payloads very slow and remove valid text such as `<info>`.

this change skips the formatter for raw output in both `write()` and `writeln()`. `OutputCleaner` is still used to remove ANSI codes and console noise.

added Pest tests for both methods including iterable messages.

Fixes #49