### PR TITLE
Document forwarding agent env vars into Docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,39 @@ That's it. PAO hooks into PHPUnit, Pest, Paratest, PHPStan, and Rector automatic
 
 > **PAO only activates when it detects an AI agent** (Claude Code, Cursor, Devin, Gemini CLI, etc.). When you or your team run tools directly in the terminal, the output is completely unchanged — same colors, same formatting, same experience. Zero impact on human workflows.
 
+### Docker & Other Containers
+
+PAO detects an agent from the environment variables of the process it runs in (`AI_AGENT`, `CLAUDECODE`, `CURSOR_AGENT`, `CODEX_*`, and friends). If your tools run inside a container — `docker compose exec`, `docker run`, Sail, DDEV — those variables stay on the host and never reach PHP, so PAO stays dormant and your agent still gets the full, verbose output.
+
+The fix is to forward the agent variables into the container. In Compose, use the **list form**, which passes each variable through from your shell and leaves it unset in the container when it's unset on the host:
+
+```yaml
+# compose.yaml
+services:
+    app:
+        environment:
+            - AI_AGENT
+            - CLAUDECODE
+            - CURSOR_AGENT
+```
+
+> Use the list form, not `AI_AGENT: ${AI_AGENT:-}`. The mapping form defines the variable as an empty string even when your host doesn't set it, and PAO treats most of these variables as present-or-absent — so an empty `CLAUDECODE` would switch every teammate's test run to JSON.
+
+You can also forward per invocation, with no changes to your Compose file. Naming a variable with no value tells Docker to copy it from your shell, and to skip it if it isn't set:
+
+```bash
+docker compose exec -e AI_AGENT -e CLAUDECODE app vendor/bin/pest
+docker run --rm -e AI_AGENT -e CLAUDECODE my-app vendor/bin/phpstan
+```
+
+If forwarding isn't practical — a CI image, a devcontainer, a wrapper script you don't control — set `PAO_FORCE` instead, which activates PAO without any agent detection:
+
+```bash
+docker compose exec -e PAO_FORCE=true app vendor/bin/pest
+```
+
+Scope `PAO_FORCE` to the commands your agent runs — documenting them in your `CLAUDE.md` or `AGENTS.md` works well — rather than baking it into the image or Compose file. Set globally, it applies to your teammates too, and they'll get JSON where they expect colors. `PAO_DISABLE=true` turns PAO back off for a single command.
+
 ## Before & After
 
 Your test suite with **1,000 tests** goes from this:


### PR DESCRIPTION
Since `pao` uses environment variables to work out whether it's being run by an agent, developers using Docker (for example, using Laravel Sail) will find that it wouldn't work. This was originally reported in #3, but since issues have been removed from Laravel First Party Projects, that information's not easily available anymore.

This updates the README to let people know what would be required to make it `pao` work over docker, so they don't need to find this out themselves. If new agents get released with a different envvar, this should hopefully be enough info for the agent to suggest the fix required for that specific agent.

I wasn't sure of the best place to put it in the README - feel free to move it somewhere else.