### PR TITLE
[1.x] Use completed runner status and retain class hook errors

### DIFF
--- a/src/Drivers/Concerns/TestResultParsable.php
+++ b/src/Drivers/Concerns/TestResultParsable.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Laravel\Pao\Drivers\Concerns;
 
 use Pest\Plugins\Parallel\Paratest\WrapperRunner;
+use PHPUnit\Event\Application\Finished as ApplicationFinished;
+use PHPUnit\Event\Application\FinishedSubscriber as ApplicationFinishedSubscriber;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\Throwable;
 use PHPUnit\Event\Facade as EventFacade;
@@ -14,14 +16,11 @@ use PHPUnit\Event\Test\Finished;
 use PHPUnit\Event\Test\FinishedSubscriber;
 use PHPUnit\Event\Test\Prepared;
 use PHPUnit\Event\Test\PreparedSubscriber;
-use PHPUnit\Event\TestRunner\ExecutionFinished;
-use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
 use PHPUnit\Event\TestRunner\ExecutionStarted;
 use PHPUnit\Event\TestRunner\ExecutionStartedSubscriber;
 use PHPUnit\TestRunner\TestResult\Facade as TestResultFacade;
 use PHPUnit\TestRunner\TestResult\Issues\Issue;
 use PHPUnit\TestRunner\TestResult\TestResult;
-use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
 
 /**
  * @internal
@@ -34,26 +33,27 @@ trait TestResultParsable
 
     public ?TestResult $testResult = null;
 
-    private bool $executionFinished = false;
+    private ?int $exitCode = null;
 
-    protected function registerExecutionFinishedSubscriber(): void
+    public function recordExitCode(int $exitCode): void
+    {
+        $this->exitCode = $exitCode;
+    }
+
+    protected function registerApplicationFinishedSubscriber(): void
     {
         try {
-            $markFinished = function (): void {
-                $this->executionFinished = true;
-            };
-
             EventFacade::instance()->registerSubscriber(
-                new readonly class($markFinished) implements ExecutionFinishedSubscriber
+                new readonly class($this->recordExitCode(...)) implements ApplicationFinishedSubscriber
                 {
                     /**
-                     * @param  \Closure(): void  $markFinished
+                     * @param  \Closure(int): void  $recordExitCode
                      */
-                    public function __construct(private \Closure $markFinished) {}
+                    public function __construct(private \Closure $recordExitCode) {}
 
-                    public function notify(ExecutionFinished $event): void
+                    public function notify(ApplicationFinished $event): void
                     {
-                        ($this->markFinished)();
+                        ($this->recordExitCode)($event->shellExitCode());
                     }
                 },
             );
@@ -118,6 +118,10 @@ trait TestResultParsable
             return null;
         }
 
+        if ($this->exitCode === null && $testResult->wasSuccessful()) {
+            return null;
+        }
+
         if ($testResult->numberOfTestsRun() > 0 || ProfileCollector::hasExecutionStarted()) {
             return $this->parseTestResult($testResult);
         }
@@ -136,7 +140,7 @@ trait TestResultParsable
             return WrapperRunner::$result;
         }
 
-        if (! $this->executionFinished) {
+        if ($this->exitCode === null) {
             return null;
         }
 
@@ -164,7 +168,6 @@ trait TestResultParsable
         $risky = $testResult->numberOfTestsWithTestConsideredRiskyEvents();
         $ignoredByBaseline = $testResult->numberOfIssuesIgnoredByBaseline();
         $hasNoTests = $tests === 0;
-        $noTestsFoundAndFailsOnEmpty = $hasNoTests && $this->failsOnEmptyTestSuite();
 
         $durationMs = ProfileCollector::durationMs();
 
@@ -208,28 +211,34 @@ trait TestResultParsable
         $errorDetails = [];
 
         foreach ($testResult->testErroredEvents() as $event) {
+            $throwable = $event->throwable();
+            $message = trim($throwable->message());
+
             if ($event instanceof Errored) {
                 $test = $event->test();
-                $throwable = $event->throwable();
-                $message = trim($throwable->message());
                 $file = $test->file();
                 $line = $test instanceof TestMethod ? $test->line() : 0;
-
-                [$file, $line] = $this->resolveTestLocation($file, $line, $throwable);
-
-                $errorDetails[] = $this->buildTestDetail(
-                    $test instanceof TestMethod ? $test->nameWithClass() : $test->id(),
-                    $file,
-                    $line,
-                    $message,
-                    $throwable,
-                );
+                $name = $test instanceof TestMethod ? $test->nameWithClass() : $test->id();
+            } else {
+                $file = '';
+                $line = 0;
+                $name = $event->testClassName().'::'.$event->calledMethod()->methodName();
             }
+
+            [$file, $line] = $this->resolveTestLocation($file, $line, $throwable);
+
+            $errorDetails[] = $this->buildTestDetail(
+                $name,
+                $file,
+                $line,
+                $message,
+                $throwable,
+            );
         }
 
         /** @var array<string, mixed> $result */
         $result = [
-            'result' => $testResult->wasSuccessful() && ! $noTestsFoundAndFailsOnEmpty ? 'passed' : 'failed',
+            'result' => $this->exitCode === 0 ? 'passed' : 'failed',
             'tests' => $tests,
             'passed' => $tests - $failedCount - $erroredCount - $skipped,
             'assertions' => $assertions,
@@ -355,15 +364,6 @@ trait TestResultParsable
     private function isVendorFrame(string $frame): bool
     {
         return str_contains($frame, '/vendor/') || str_contains($frame, '\\vendor\\');
-    }
-
-    private function failsOnEmptyTestSuite(): bool
-    {
-        try {
-            return ConfigurationRegistry::get()->failOnEmptyTestSuite();
-        } catch (\Throwable) {
-            return true;
-        }
     }
 
     /**

--- a/src/Drivers/Paratest/Starter.php
+++ b/src/Drivers/Paratest/Starter.php
@@ -25,7 +25,6 @@ final class Starter extends BaseStarter
     {
         $this->registerNullFilter();
         $this->startTimer();
-        $this->registerExecutionFinishedSubscriber();
         $this->silenceStdout();
 
         /** @var list<string> $serverArgv */

--- a/src/Drivers/Paratest/WrapperRunner.php
+++ b/src/Drivers/Paratest/WrapperRunner.php
@@ -89,6 +89,14 @@ final readonly class WrapperRunner implements RunnerInterface
         /** @var int $exitCode */
         $exitCode = $r->getMethod('complete')->invoke($runner, $result);
 
+        if (Execution::running()) {
+            $driver = Execution::current()->driver;
+
+            if ($driver instanceof Starter) {
+                $driver->recordExitCode($exitCode);
+            }
+        }
+
         return $exitCode;
     }
 

--- a/src/Drivers/Pest/Plugin.php
+++ b/src/Drivers/Pest/Plugin.php
@@ -6,13 +6,14 @@ namespace Laravel\Pao\Drivers\Pest;
 
 use Laravel\Pao\Execution;
 use Pest\Contracts\Plugins\HandlesArguments;
+use Pest\Contracts\Plugins\ObservesExitCode;
 
 /**
  * @internal
  *
  * @codeCoverageIgnore
  */
-final class Plugin implements HandlesArguments
+final class Plugin implements HandlesArguments, ObservesExitCode
 {
     public function __construct()
     {
@@ -38,5 +39,16 @@ final class Plugin implements HandlesArguments
         }
 
         return $arguments;
+    }
+
+    public function observeExitCode(int $exitCode): void
+    {
+        if (Execution::running()) {
+            $driver = Execution::current()->driver;
+
+            if ($driver instanceof Starter) {
+                $driver->recordExitCode($exitCode);
+            }
+        }
     }
 }

--- a/src/Drivers/Pest/Starter.php
+++ b/src/Drivers/Pest/Starter.php
@@ -26,7 +26,6 @@ final class Starter extends BaseStarter
     {
         $this->registerNullFilter();
         $this->startTimer();
-        $this->registerExecutionFinishedSubscriber();
         $this->saveStdout();
         $this->silenceStdout();
 

--- a/src/Drivers/Phpunit/Starter.php
+++ b/src/Drivers/Phpunit/Starter.php
@@ -25,7 +25,7 @@ final class Starter extends BaseStarter
     {
         $this->registerNullFilter();
         $this->startTimer();
-        $this->registerExecutionFinishedSubscriber();
+        $this->registerApplicationFinishedSubscriber();
         $this->registerProfileSubscriber();
 
         /** @var list<string> $serverArgv */

--- a/tests/Drivers/TestResultTest.php
+++ b/tests/Drivers/TestResultTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+dataset('test result runners', [
+    'phpunit' => ['phpunit', []],
+    'paratest' => ['paratest', ['--processes=2']],
+    'pest' => ['pest', []],
+    'pest parallel' => ['pest', ['--parallel', '--processes=2']],
+]);
+
+it('matches the exit status after Pest coverage policies', function (): void {
+    foreach ([[], ['--parallel', '--processes=2']] as $arguments) {
+        foreach (['--min', '--exactly'] as $policy) {
+            foreach ([0, 100] as $threshold) {
+                $extraArgs = [
+                    ...$arguments,
+                    '--coverage',
+                    '--coverage-filter',
+                    'src',
+                    $policy.'='.$threshold,
+                ];
+                $native = runWith('pest', 'PassingTest', withAgent: false, extraArgs: $extraArgs, extraEnv: ['PARATEST' => false]);
+                $process = runWith('pest', 'PassingTest', extraArgs: $extraArgs, extraEnv: ['PARATEST' => false]);
+                $output = decodeOutput($process);
+
+                expect(cleanOutput($native->getOutput()))->toContain('Total: 0.0 %')
+                    ->and($native->getExitCode())->toBe($threshold === 0 ? 0 : 1)
+                    ->and($process->getExitCode())->toBe($native->getExitCode())
+                    ->and($output['result'])->toBe($process->isSuccessful() ? 'passed' : 'failed')
+                    ->and($output['tests'])->toBe(2)
+                    ->and($output['passed'])->toBe(2);
+            }
+        }
+    }
+});
+
+it('matches the exit status with and without strict outcome policies', function (string $binary, array $arguments, string $filter, string $flag): void {
+    foreach ([false, true] as $strict) {
+        $extraArgs = $strict ? [...$arguments, $flag] : $arguments;
+        $native = runWith($binary, $filter, withAgent: false, extraArgs: $extraArgs);
+        $process = runWith($binary, $filter, extraArgs: $extraArgs);
+        $output = decodeOutput($process);
+
+        expect($native->getExitCode())->toBe($strict ? 1 : 0)
+            ->and($process->getExitCode())->toBe($native->getExitCode())
+            ->and($output['result'])->toBe($process->isSuccessful() ? 'passed' : 'failed');
+    }
+})->with('test result runners')->with([
+    'warning' => ['WarningTest', '--fail-on-warning'],
+    'notice' => ['NoticeTest', '--fail-on-notice'],
+    'deprecation' => ['DeprecationTest', '--fail-on-deprecation'],
+    'skipped' => ['SkippedTest', '--fail-on-skipped'],
+    'incomplete' => ['IncompleteTest', '--fail-on-incomplete'],
+    'risky' => ['RiskyTest', '--fail-on-risky'],
+]);
+
+it('includes diagnostics for errors in class hooks', function (string $binary, array $arguments, string $filter, string $method, string $message): void {
+    $native = runWith($binary, $filter, withAgent: false, extraArgs: $arguments);
+    $process = runWith($binary, $filter, extraArgs: $arguments);
+    $output = decodeOutput($process);
+
+    expect($native->isSuccessful())->toBeFalse()
+        ->and($process->getExitCode())->toBe($native->getExitCode())
+        ->and($output['result'])->toBe('failed')
+        ->and($output['errors'])->toBe(1)
+        ->and($output['error_details'])->toHaveCount(1)
+        ->and($output['error_details'][0]['test'])->toEndWith($filter.'::'.$method)
+        ->and($output['error_details'][0]['file'])->toEndWith($filter.'.php')
+        ->and($output['error_details'][0]['line'])->toBe(14)
+        ->and($output['error_details'][0]['message'])->toBe($message);
+})->with('test result runners')->with([
+    'before class' => ['BeforeClassExceptionTest', 'setUpBeforeClass', 'Error inside the beforeClass hook'],
+    'after class' => ['AfterClassExceptionTest', 'tearDownAfterClass', 'Error inside the afterClass hook'],
+]);

--- a/tests/Fixtures/AfterClassExceptionTest.php
+++ b/tests/Fixtures/AfterClassExceptionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class AfterClassExceptionTest extends TestCase
+{
+    public static function tearDownAfterClass(): void
+    {
+        throw new RuntimeException('Error inside the afterClass hook');
+    }
+
+    public function test_it_passes(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Fixtures/BeforeClassExceptionTest.php
+++ b/tests/Fixtures/BeforeClassExceptionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class BeforeClassExceptionTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        throw new RuntimeException('Error inside the beforeClass hook');
+    }
+
+    public function test_it_never_runs(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Unit/Drivers/Paratest/WrapperRunnerTest.php
+++ b/tests/Unit/Drivers/Paratest/WrapperRunnerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Laravel\Pao\Drivers\Paratest\Starter;
 use Laravel\Pao\Drivers\Paratest\WrapperRunner;
 use PHPUnit\TestRunner\TestResult\TestResult;
 
@@ -63,6 +64,17 @@ function mergeWorkerResults(TestResult $sum, array $workerResults): TestResult
 
     return $merged;
 }
+
+it('does not report successful worker results before the runner supplies its exit code', function (int $exitCode, string $status): void {
+    $driver = new Starter;
+    $driver->testResult = makeTestResult(['numberOfTests' => 1, 'numberOfTestsRun' => 1]);
+
+    expect($driver->parse())->toBeNull();
+
+    $driver->recordExitCode($exitCode);
+
+    expect($driver->parse()['result'])->toBe($status);
+})->with([[0, 'passed'], [1, 'failed'], [2, 'failed'], [42, 'failed']]);
 
 it('merges worker results on every supported phpunit version', function (): void {
     $merged = mergeWorkerResults(


### PR DESCRIPTION
PAO can report `"result":"passed"` when a runner exits unsuccessfully because of a strict outcome policy or a Pest coverage threshold, and class hook exceptions can be missing from `error_details`. This change derives success from the runner's completion status, observes Pest after all output plugins, and serializes class hook errors through the existing location and trace helpers. Successful test results are withheld until a completion status is available, while collected failures remain visible if a runner aborts.

Regression coverage includes six strict outcome policies and both class hooks across PHPUnit, ParaTest, Pest, and parallel Pest; passing and failing `--min`/`--exactly` coverage thresholds in both Pest modes; and incomplete worker-result collection.

Validation on macOS / PHP 8.5.10 with the companion Pest patches applied:

- PHPUnit 13.3.2 / Pest 5.1.4 / ParaTest 7.24.1: 292 passed, one existing version-dependent skip, 914 assertions; repository coverage target 100%.
- PHPUnit 12.5.33 / Pest 4.7.8 / ParaTest 7.20.0: 292 passed, one existing version-dependent skip, 910 assertions; repository coverage target 100%.
- PHPStan, Pint, Rector dry-run, type coverage 100%, and whitespace checks passed.

Dependency: this draft requires the Pest `ObservesExitCode` hook in https://github.com/pestphp/pest/pull/1905 and its 4.x backport in https://github.com/pestphp/pest/pull/1906. Before merging PAO, Pest must release that hook and PAO's Composer constraints must require those actual releases. The current stable Pest releases alone do not provide this interface; no future release numbers are assumed here.

The complete upstream PHP/OS/dependency matrix has not been run. The coverage metric retains PAO's existing exclusions.

Prepared with AI assistance.
