### PR TITLE
[1.x] Fixes empty output and exit code 255 when a test run dies with a fatal error

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -33,8 +33,12 @@ unset($_SERVER['COLLISION_PRINTER']);
 $_SERVER['PEST_PARALLEL_NO_OUTPUT'] = '1';
 
 $pid = getmypid();
+$reservedMemory = str_repeat(' ', 128 * 1024);
 
-register_shutdown_function(function () use ($pid): void {
+register_shutdown_function(function () use ($pid, &$reservedMemory): void {
+    $reservedMemory = null;
+    $error = error_get_last();
+
     if (getmypid() !== $pid) {
         return;
     }
@@ -43,37 +47,59 @@ register_shutdown_function(function () use ($pid): void {
         return;
     }
 
-    $execution = Execution::current();
+    $fatalError = is_array($error) && in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR], true) ? $error : null;
 
-    $result = $execution->driver->parse() ?: [];
+    set_error_handler(static fn (): bool => true);
 
-    $captured = trim(UserFilters\CaptureFilter::output());
+    try {
+        $execution = Execution::current();
 
-    $execution->restoreStdout();
+        $result = $execution->driver->parse() ?: [];
 
-    if ($captured !== '') {
-        $captured = OutputCleaner::clean($captured);
+        if ($fatalError !== null) {
+            $result = ['result' => 'failed'] + $result;
 
-        $lines = array_values(array_filter(
-            array_map(trim(...), explode("\n", $captured)),
-            fn (string $line): bool => $line !== ''
-                && ! preg_match('/^[.st!]+$/', $line)
-                && ! preg_match('/^(Tests:|Duration:|Parallel:|Time:|Generating code coverage)\s/', $line)
-                && ! preg_match('/^(INFO\s+)?No tests found\.?$/i', $line)
-                && ! str_ends_with($line, 'by Sebastian Bergmann and contributors.'),
-        ));
-
-        if ($lines !== []) {
-            $existing = is_array($result['raw'] ?? null) ? array_values($result['raw']) : [];
-
-            $result['raw'] = [...$existing, ...$lines];
+            $result['fatal_error'] = [
+                'message' => $fatalError['message'],
+                'file' => $fatalError['file'],
+                'line' => $fatalError['line'],
+            ];
         }
-    }
 
-    if ($result !== []) {
-        $result = ['tool' => $execution->driver->name()] + $result;
+        $captured = is_resource($execution->filter) ? trim(UserFilters\CaptureFilter::output()) : '';
 
-        fwrite(STDOUT, json_encode($result, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR).PHP_EOL);
+        $execution->restoreStdout();
+
+        if ($captured !== '') {
+            $captured = OutputCleaner::clean($captured);
+
+            $lines = array_values(array_filter(
+                array_map(trim(...), explode("\n", $captured)),
+                fn (string $line): bool => $line !== ''
+                    && ! preg_match('/^[.st!]+$/', $line)
+                    && ! preg_match('/^(Tests:|Duration:|Parallel:|Time:|Generating code coverage)\s/', $line)
+                    && ! preg_match('/^(INFO\s+)?No tests found\.?$/i', $line)
+                    && ! str_ends_with($line, 'by Sebastian Bergmann and contributors.'),
+            ));
+
+            if ($lines !== []) {
+                $existing = is_array($result['raw'] ?? null) ? array_values($result['raw']) : [];
+
+                $result['raw'] = [...$existing, ...$lines];
+            }
+        }
+
+        if ($result !== []) {
+            $result = ['tool' => $execution->driver->name()] + $result;
+
+            $execution->writeStdout(json_encode($result, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR).PHP_EOL);
+        }
+    } catch (\Throwable $throwable) {
+        if ($fatalError === null) {
+            throw $throwable;
+        }
+    } finally {
+        restore_error_handler();
     }
 });
 

--- a/src/Execution.php
+++ b/src/Execution.php
@@ -77,9 +77,7 @@ final class Execution
 
     public function restoreStdout(): void
     {
-        if (is_resource($this->filter)) {
-            stream_filter_remove($this->filter);
-
+        if (is_resource($this->filter) && stream_filter_remove($this->filter)) {
             $this->filter = null;
         }
     }
@@ -95,7 +93,16 @@ final class Execution
         $this->restoreStdout();
 
         if ($captured !== '') {
-            fwrite(STDOUT, $captured);
+            $this->writeStdout($captured);
         }
+    }
+
+    public function writeStdout(string $output): void
+    {
+        if (is_resource($this->filter) && ! is_resource($this->stdout)) {
+            $this->stdout = fopen('php://stdout', 'w') ?: null;
+        }
+
+        fwrite(is_resource($this->stdout) ? $this->stdout : STDOUT, $output);
     }
 }

--- a/tests/Drivers/EdgeCasesTest.php
+++ b/tests/Drivers/EdgeCasesTest.php
@@ -136,6 +136,48 @@ it('does not emit a result when the run is aborted before it finishes', function
         ->and($process->getOutput())->not->toContain('"result"');
 });
 
+it('adds a summary to a run that dies from a fatal error and keeps its exit code', function (string $binary, string $filter, string $message): void {
+    $phpArgs = ['-d', 'display_errors=0', '-d', 'log_errors=0'];
+
+    $withoutPao = runWith($binary, $filter, extraEnv: ['PAO_DISABLE' => '1'], phpArgs: $phpArgs);
+    $withPao = runWith($binary, $filter, phpArgs: $phpArgs);
+
+    expect($withPao->getExitCode())->toBe($withoutPao->getExitCode());
+
+    $output = cleanOutput($withPao->getOutput());
+
+    expect(preg_match('/^\{"tool":.*$/m', $output, $matches))->toBe(1);
+
+    $summary = json_decode($matches[0], associative: true, flags: JSON_THROW_ON_ERROR);
+    $rest = trim((string) preg_replace('/^\{"tool":.*\n?/m', '', $output));
+
+    expect($summary['tool'])->toBe($binary)
+        ->and($summary['result'])->toBe('failed')
+        ->and($summary['fatal_error']['message'])->toContain($message)
+        ->and(normalizePath($summary['fatal_error']['file']))->toContain('tests/Fixtures/'.$filter.'.php')
+        ->and(cleanOutput($withoutPao->getOutput()))->toMatch('/'.preg_quote($rest, '/').'\z/');
+})->with([
+    'pest, compile error' => ['pest', 'RedeclaredFunctionTest', 'Cannot redeclare'],
+    'pest, memory exhaustion' => ['pest', 'MemoryExhaustionTest', 'Allowed memory size'],
+    'phpunit, compile error' => ['phpunit', 'RedeclaredFunctionTest', 'Cannot redeclare'],
+    'phpunit, memory exhaustion' => ['phpunit', 'MemoryExhaustionTest', 'Allowed memory size'],
+    'phpunit, memory exhausted by small allocations' => ['phpunit', 'MemoryExhaustedBySmallAllocationsTest', 'Allowed memory size'],
+]);
+
+it('reports a fatal error with what the test printed when no memory is left', function (): void {
+    $process = runWith('pest', 'MemoryExhaustedBySmallAllocationsTest', phpArgs: ['-d', 'display_errors=0', '-d', 'log_errors=0']);
+    $output = cleanOutput($process->getOutput());
+
+    expect($process->getExitCode())->not->toBe(0)
+        ->and(preg_match('/^\{"tool":.*$/m', $output, $matches))->toBe(1);
+
+    $summary = json_decode($matches[0], associative: true, flags: JSON_THROW_ON_ERROR);
+
+    expect($summary['result'])->toBe('failed')
+        ->and($summary['fatal_error']['message'])->toContain('Allowed memory size')
+        ->and($summary['raw'])->toContain('output before the process dies');
+});
+
 it('does not break tests that spawn child processes', function (): void {
     $output = decodeOutput(runWith('phpunit', 'ExecTest'));
 

--- a/tests/Fixtures/MemoryExhaustedBySmallAllocationsTest.php
+++ b/tests/Fixtures/MemoryExhaustedBySmallAllocationsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+final class MemoryExhaustedBySmallAllocationsTest extends TestCase
+{
+    public function test_passes_before_the_process_dies(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function test_exhausts_the_memory_limit_with_small_allocations(): void
+    {
+        fwrite(STDOUT, "output before the process dies\n");
+
+        ini_set('memory_limit', (string) (memory_get_usage(true) + 8 * 1024 * 1024));
+
+        $list = null;
+
+        for ($i = 0; $i < 400_000; $i++) {
+            $list = [$list, 'x'.$i];
+        }
+
+        $this->assertNotNull($list);
+    }
+}

--- a/tests/Fixtures/MemoryExhaustionTest.php
+++ b/tests/Fixtures/MemoryExhaustionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+final class MemoryExhaustionTest extends TestCase
+{
+    public function test_passes_before_the_process_dies(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function test_exhausts_the_memory_limit(): void
+    {
+        ini_set('memory_limit', (string) (memory_get_usage(true) + 16 * 1024 * 1024));
+
+        $chunks = [];
+
+        for ($i = 0; $i < 64; $i++) {
+            $chunks[] = str_repeat('x', 1024 * 1024);
+        }
+
+        $this->assertCount(64, $chunks);
+    }
+}

--- a/tests/Fixtures/RedeclaredFunctionTest.php
+++ b/tests/Fixtures/RedeclaredFunctionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+final class RedeclaredFunctionTest extends TestCase
+{
+    public function test_passes_before_the_process_dies(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function test_dies_with_a_compile_error(): void
+    {
+        eval('function strlen() {}');
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -18,9 +18,9 @@ function buildAgentEnvironment(bool $withAgent = true): array
     return $env;
 }
 
-function runWith(string $binary, string $filter, bool $withAgent = true, array $extraArgs = [], string $config = 'tests/Fixtures/phpunit.xml', array $extraEnv = []): Process
+function runWith(string $binary, string $filter, bool $withAgent = true, array $extraArgs = [], string $config = 'tests/Fixtures/phpunit.xml', array $extraEnv = [], array $phpArgs = []): Process
 {
-    $command = [PHP_BINARY, 'vendor/bin/'.$binary, '--configuration', $config, '--filter', $filter, ...$extraArgs];
+    $command = [PHP_BINARY, ...$phpArgs, 'vendor/bin/'.$binary, '--configuration', $config, '--filter', $filter, ...$extraArgs];
 
     $process = new Process(
         command: $command,


### PR DESCRIPTION
When a test dies mid-run with a PHP fatal error (memory exhaustion, a redeclared function, anything PHPUnit can't catch), PAO's own shutdown function crashes. It runs before PHPUnit's and Pest's shutdown handlers, so it takes them down too. Under Pest the run exits with `255` instead of `2` or `1`, and PHPUnit's "Premature end of PHP process when running …" line is lost; with `display_errors` off, nothing is printed at all. Under PHPUnit it doesn't crash, but no summary is printed either. An agent ends up knowing less than a person running the same command without PAO.

With this PR the shutdown function survives. The runner's exit code and crash report stay as they are, and the summary reports the error:

```
{"tool":"pest","result":"failed","fatal_error":{"message":"Allowed memory size of 29360128 bytes exhausted (tried to allocate 1052672 bytes)","file":"tests/Fixtures/MemoryExhaustionTest.php","line":23}}
Fatal error: Premature end of PHPUnit's PHP process. Use display_errors=On to see the error message.
```

**Why it happens.** After a fatal error, PHP no longer runs userland stream filters ([php-src](https://github.com/php/php-src/blob/7f3d3de1a280f3fb573bd7976185ea94d11be606/ext/standard/user_filters.c#L141-L144)). So `stream_filter_remove()` can't remove `CaptureFilter` from `STDOUT`: it returns `false` with a warning ([php-src](https://github.com/php/php-src/blob/7f3d3de1a280f3fb573bd7976185ea94d11be606/ext/standard/streamsfuncs.c#L1324-L1327)), and whatever is written to `STDOUT` afterwards is dropped. The test that died never finished, so PHPUnit's error handler is still installed. It turns the warning into `NoTestCaseObjectOnCallStackException`, which is fatal inside a shutdown function and stops every shutdown function registered after PAO's. `@` wouldn't help: PHPUnit only ignores suppressed errors from files on its `ExcludeList` ([phpunit](https://github.com/sebastianbergmann/phpunit/blob/12.5.33/src/Runner/ErrorHandler.php#L109-L130)).

**What changes.** Only `src/Autoload.php` and `src/Execution.php` change, and only in how they behave once the process is already dying from a fatal error. Clean runs are byte-for-byte unchanged; I compared pest, `pest --parallel`, phpunit, paratest, phpstan and rector against `1.x`.

- The shutdown function reads `error_get_last()` first and runs under a no-op error handler. PHPUnit's handler never sees PAO's warnings, and the handlers after PAO still find the original error. If PAO itself throws after a fatal error, the exception is swallowed; in any other run it is rethrown as before.
- `restoreStdout()` checks what `stream_filter_remove()` returns. When the filter can't be removed, the summary is written through a separately opened `php://stdout` handle, or through the one the Pest driver already saves.
- A 128 KB block reserved at startup is freed first, and the capture filter is only read when one is attached. That leaves room to build the summary when the process ran out of memory.
- After a fatal error, the summary sets `"result": "failed"` and adds `fatal_error` with the message, file and line. The fatal types are `E_ERROR`, `E_PARSE`, `E_CORE_ERROR`, `E_COMPILE_ERROR`, `E_USER_ERROR` and `E_RECOVERABLE_ERROR`. Whatever else the summary already had stays in it. As a side effect, a fatal error after the tests finished (for example in an extension) no longer reports `"result": "passed"`.

`fatal_error` is the only new key; happy to rename it if you prefer something else, such as `crash`.

**Tests.** Three new fixtures kill the process mid-run:

- a redeclared function;
- memory exhausted by 1 MB strings;
- memory exhausted by small allocations after the test printed a line.

`EdgeCasesTest` runs them through `pest` and `phpunit` with `display_errors=0`, once with `PAO_DISABLE=1` and once with PAO active. It asserts that:

- the exit codes match;
- the summary reports the fatal error;
- PAO prints nothing but its summary on top of the runner's own output.

A separate test checks that a Pest run that runs out of memory still reports what the test printed. All of these fail on `1.x` and pass here on PHP 8.3, 8.4 and 8.5, and `composer test` passes.

<details>
<summary>Reproduction</summary>

Without PAO or PHPUnit, this is what PAO does in agent mode:

```php
<?php
final class Capture extends php_user_filter
{
    public function filter($in, $out, &$consumed, bool $closing): int
    {
        while ($bucket = stream_bucket_make_writeable($in)) {
            $consumed += $bucket->datalen;
            $bucket->data = '';
            stream_bucket_append($out, $bucket);
        }

        return PSFS_PASS_ON;
    }
}

stream_filter_register('capture', Capture::class);
$filter = stream_filter_append(STDOUT, 'capture', STREAM_FILTER_WRITE);
$saved = fopen('php://stdout', 'w'); // an unfiltered handle

register_shutdown_function(function () use ($filter, $saved): void {
    $removed = @stream_filter_remove($filter);
    $error = error_get_last()['message'] ?? null;
    $written = fwrite(STDOUT, "summary\n");
    fwrite($saved, json_encode(compact('removed', 'error', 'written')).PHP_EOL);
});

if (($argv[1] ?? '') === 'fatal') {
    eval('function strlen() {}'); // any fatal: OOM, compile error, uncaught error
}
```

`php -d display_errors=0 repro.php` prints `summary` and `{"removed":true,"error":null,"written":8}`. `php -d display_errors=0 repro.php fatal` prints `{"removed":false,"error":"stream_filter_remove(): Unable to flush filter, not removing","written":false}` and exits with `255`. The separately opened handle still works.

With Pest, on `1.x` (v1.1.5) with pestphp/pest 4.7.8, phpunit/phpunit 12.5.33 and PHP 8.3, using the fixtures from this PR:

```bash
PAO_FORCE=1 php -d display_errors=0 -d log_errors=0 vendor/bin/pest --configuration tests/Fixtures/phpunit.xml --filter MemoryExhaustionTest
```

| Second test | `display_errors` | `PAO_DISABLE=1` | PAO active, `1.x` | PAO active, this PR |
|---|---|---|---|---|
| exhausts memory | `0` | exit 2: `Premature end of PHPUnit's PHP process…` | exit 255, **no output** | exit 2: summary, then the same line |
| exhausts memory | `stderr` | exit 2: the OOM error, then `Premature end of PHP process when running …` | exit 255: the OOM error, then the trace below | exit 2: the same output, plus the summary |
| `eval('function strlen() {}');` | `0` | exit 1: Pest's `FatalException` render | exit 255, **no output** | exit 1: summary (see notes) |
| `eval('function strlen() {}');` | `stderr` | exit 1: the fatal error, then Pest's render | exit 255: the fatal error, then the trace below | exit 1: the fatal error, plus the summary |

Under `vendor/bin/phpunit` the exit code is `2` in every case. `1.x` prints no summary; this PR adds one. v1.0.6 crashes the same way, but it has no `PAO_FORCE`, so use an agent variable such as `AI_AGENT=1`. Paths below are shortened to be relative to the repository:

```
Fatal error: Allowed memory size of 29360128 bytes exhausted (tried to allocate 1052672 bytes) in tests/Fixtures/MemoryExhaustionTest.php on line 23
Fatal error: Uncaught PHPUnit\Event\Code\NoTestCaseObjectOnCallStackException: Cannot find TestCase object on call stack in vendor/phpunit/phpunit/src/Util/Test.php:39
Stack trace:
#0 vendor/phpunit/phpunit/src/Event/Value/Test/TestMethodBuilder.php(56): PHPUnit\Util\Test::currentTestCase()
#1 vendor/phpunit/phpunit/src/Runner/ErrorHandler.php(130): PHPUnit\Event\Code\TestMethodBuilder::fromCallStack()
#2 [internal function]: PHPUnit\Runner\ErrorHandler->__invoke(2, 'stream_filter_r...', '...', 81)
#3 src/Execution.php(81): stream_filter_remove(Resource id #277)
#4 src/Autoload.php(52): Laravel\Pao\Execution->restoreStdout()
#5 [internal function]: Laravel\Pao\{closure}()
#6 {main}
  thrown in vendor/phpunit/phpunit/src/Util/Test.php on line 39
```

</details>

<details>
<summary>Notes and limitations</summary>

- **#40.** That PR made a run killed mid-test report nothing instead of `"result":"passed"`. It is unchanged here: no partial counts are reported, and `AbortedRunTest` still prints nothing. The new summary is triggered by a fatal error only. "`ExecutionFinished` never fired" would also fire for Pest plugins that exit before any test runs, such as `--type-coverage`.
- **#26.** It was closed as fixed in Pest, and with PAO disabled that holds. With PAO active, the load-time case (the same function declared in two test files) still prints nothing on `1.x`. PHPUnit's error handler isn't installed yet, so nothing crashes, but PAO has nothing to report and `STDOUT` stays filtered. This PR prints the summary. The exit code stays `255` instead of Pest's `1`: with PAO running, `KernelDump::enable()` skips its `ob_start()` ([pest](https://github.com/pestphp/pest/blob/v4.7.8/src/KernelDump.php#L30-L34)), and `disable()`'s `@ob_clean()` ([pest](https://github.com/pestphp/pest/blob/v4.7.8/src/KernelDump.php#L46-L48)) raises a notice that replaces `error_get_last()` before `Kernel::shutdown()` reads it ([pest](https://github.com/pestphp/pest/blob/v4.7.8/src/Kernel.php#L147-L152)). Reading `error_get_last()` before `$this->terminate()` in Pest would fix that.
- **#62.** No overlap: this PR doesn't touch any of its files.
- **Pest's fatal error render stays hidden under PAO.** Symfony Console writes to the `STDOUT` constant outside Windows ([symfony/console](https://github.com/symfony/console/blob/v7.4.18/Output/ConsoleOutput.php#L133-L143)), and after a fatal error the filter can't be removed, so the render is hidden like the rest of Pest's output. The summary carries the error as PHP reports it. PHPUnit's report uses `print` and isn't affected.
- **Pest when memory is completely exhausted.** Whether Pest's own renderer survives depends on how much memory is left, with or without PAO. Because PAO turns Pest's printer off, the renderer's classes may not be loaded yet. PAO's summary is printed either way.
- **Also changed or unchanged:**
  - Commands PAO passes through unchanged (e.g. `phpstan analyse --generate-baseline`) also get the summary line when they die from a fatal error.
  - Fatal errors inside paratest or `pest --parallel` workers behave as before.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
